### PR TITLE
Inclui declaração lexer na gramática

### DIFF
--- a/code/0
+++ b/code/0
@@ -321,6 +321,20 @@ make_antlr_grammar = { ws_char } => (
   grammar_decl = {
     type: "sequence"
     parts: [
+      { name: "kind" grammar: {
+        type: "repetition"
+        grammar: {
+          type: "alternative"
+          options: [
+            { type: "symbol" text: "lexer" }
+            { type: "symbol" text: "parser" }
+          ]
+        }
+        minimum: 0
+        maximum: 1
+        format: "text"
+      }}
+      { name: "ws_kind" grammar: opt_ws }
       { name: "keyword" grammar: { type: "symbol" text: "grammar" } }
       { name: "ws1" grammar: ws }
       { name: "name" grammar: identifier }

--- a/tests/0
+++ b/tests/0
@@ -34,6 +34,8 @@ result5 = antlr.parse({ input: test_input5 })
 test_ast = {
   ws_start: ""
   grammar_decl: {
+    kind: ""
+    ws_kind: ""
     keyword: "grammar"
     ws1: " "
     name: "Example"
@@ -215,6 +217,58 @@ expr: 'hello' // middle comment
           })
           [
             unitest.equals([ result.success 1 ])
+          ]
+        )
+      })
+      unitest.describe({
+        name: "Lexer grammar declaration"
+        tests: (
+          result = antlr.parse({
+            input: "lexer grammar MyLexer;"
+          })
+          [
+            unitest.equals([ result.success 1 ])
+            unitest.equals([ (result.success == 1 ? result.value.grammar_decl.kind : "N/A") "lexer" ])
+            unitest.equals([ (result.success == 1 ? result.value.grammar_decl.ws_kind : "N/A") " " ])
+            unitest.equals([ (result.success == 1 ? result.value.grammar_decl.name : "N/A") "MyLexer" ])
+          ]
+        )
+      })
+      unitest.describe({
+        name: "Parser grammar declaration"
+        tests: (
+          result = antlr.parse({
+            input: "parser grammar MyParser;"
+          })
+          [
+            unitest.equals([ result.success 1 ])
+            unitest.equals([ (result.success == 1 ? result.value.grammar_decl.kind : "N/A") "parser" ])
+            unitest.equals([ (result.success == 1 ? result.value.grammar_decl.ws_kind : "N/A") " " ])
+            unitest.equals([ (result.success == 1 ? result.value.grammar_decl.name : "N/A") "MyParser" ])
+          ]
+        )
+      })
+      unitest.describe({
+        name: "Generate lexer grammar from AST"
+        tests: (
+          test_ast_lexer = {
+            ws_start: ""
+            grammar_decl: {
+              kind: "lexer"
+              ws_kind: " "
+              keyword: "grammar"
+              ws1: " "
+              name: "MyLexer"
+              ws2: ""
+              semicolon: ";"
+            }
+            rules: []
+            ws_end: ""
+          }
+          result_lexer = antlr.generate({ ast: test_ast_lexer })
+          [
+            unitest.equals([ result_lexer.success 1 ])
+            unitest.equals([ (result_lexer.success == 1 ? result_lexer.output : "N/A") "lexer grammar MyLexer;" ])
           ]
         )
       })


### PR DESCRIPTION
Neste PR, incluí suporte para as declarações "lexer grammar" e "parser grammar" na gramática ANTLR definida em `code/0`.

Alterações realizadas:
- Modificação de `grammar_decl` em `code/0` para incluir os campos opcionais `kind` e `ws_kind`.
- Atualização do teste de geração existente em `tests/0` para incluir os novos campos no AST de teste.
- Adição de novos testes em `tests/0` para verificar o parsing de `lexer grammar` e `parser grammar`, bem como sua regeneração.

Todos os 35 testes em `tests/0` estão passando.

---
*PR created automatically by Jules for task [3030306707156203520](https://jules.google.com/task/3030306707156203520) started by @angelonuffer*