### PR TITLE
Update README.md to match implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,20 @@ This library uses [dialect](https://github.com/angelonuffer/dialect) for parsing
 
 ## Features
 
-- ✅ Parse ANTLR grammar declarations (`grammar Name;`)
+- ✅ Parse ANTLR grammar declarations (`grammar Name;`, `lexer grammar Name;`, `parser grammar Name;`)
 - ✅ Parse parser rules (lowercase names)
-- ✅ Parse lexer rules (uppercase names)
-- ✅ Support for string literals (`'text'`)
-- ✅ Support for character classes (`[a-z]`, `[A-Z0-9]`)
+- ✅ Parse lexer rules (uppercase names), including `fragment` rules
+- ✅ Support for rule alternatives (`|`)
+- ✅ Support for quantifiers (`*`, `+`, `?`, `*?`, `+?`) and bounded quantifiers (`{n}`, `{n,}`, `{n,m}`)
+- ✅ Support for parenthesized groups (up to 2 levels of nesting)
+- ✅ Support for lexer commands (`-> skip`, `-> channel(HIDDEN)`, etc.)
+- ✅ Support for `mode` declarations
+- ✅ Support for wildcard (`.`)
+- ✅ Support for string literals with escape sequences (`'text'`, `\n`, `\uXXXX`, etc.)
+- ✅ Support for character classes (`[a-z]`, `[A-Z0-9]`, `[\u0000-\uFFFF]`)
 - ✅ Comment syntax support (single-line `//` and multi-line `/* */`)
 - ✅ Generate ANTLR grammar from AST
+- ✅ Convert ANTLR AST to `dialect` grammar structures
 - ✅ Uses negation grammar type from dialect
 
 ## Usage
@@ -86,6 +93,18 @@ Generates ANTLR grammar text from an AST.
 - On success: `{ success: 1 output: <text> }`
 - On failure: `{ success: 0 }`
 
+### to_dialect : function
+
+`{ ast : object }` => `object`
+
+Converts an ANTLR grammar AST into a `dialect` grammar object.
+
+**Input:**
+- `ast`: ANTLR grammar AST structure
+
+**Output:**
+- A `dialect` grammar object where each key is a rule name and each value is a `dialect` rule definition.
+
 ### grammar : object
 
 The internal dialect grammar object used for parsing and generation.
@@ -94,35 +113,132 @@ The internal dialect grammar object used for parsing and generation.
 
 The AST follows this structure:
 
+### Root Structure
+
 ```
 {
-  ws_start: <optional whitespace before grammar>
-  grammar_decl: {
-    keyword: "grammar"
-    ws1: <whitespace>
-    name: <grammar name>
-    ws2: <optional whitespace>
-    semicolon: ";"
-  }
+  ws_start: <optional whitespace>
+  grammar_decl: <grammar_decl>
   rules: [
     {
-      ws: <whitespace before rule>
-      rule: {
-        name: <rule name>
-        ws1: <optional whitespace>
-        colon: ":"
-        ws2: <optional whitespace>
-        body: {
-          first: <rule element>
-          rest: [...]
-        }
-        ws3: <optional whitespace>
-        semicolon: ";"
-      }
+      ws: <optional whitespace>
+      rule: <lexer_rule | parser_rule | mode_decl>
     }
     ...
   ]
-  ws_end: <optional whitespace at end>
+  ws_end: <optional whitespace>
+}
+```
+
+### grammar_decl
+
+```
+{
+  kind: "lexer" | "parser" | ""
+  ws_kind: <optional whitespace>
+  keyword: "grammar"
+  ws1: <whitespace>
+  name: <identifier>
+  ws2: <optional whitespace>
+  semicolon: ";"
+}
+```
+
+### parser_rule
+
+```
+{
+  name: <parser_rule_name>
+  ws1: <optional whitespace>
+  colon: ":"
+  ws2: <optional whitespace>
+  body: <rule_body>
+  ws3: <optional whitespace>
+  semicolon: ";"
+}
+```
+
+### lexer_rule
+
+```
+{
+  fragment: [ { keyword: "fragment", ws: <whitespace> } ] | []
+  name: <lexer_rule_name>
+  ws1: <optional whitespace>
+  colon: ":"
+  ws2: <optional whitespace>
+  body: <rule_body>
+  ws_command: <optional whitespace>
+  commands: [
+    {
+      arrow: "->"
+      ws1: <optional whitespace>
+      first: <lexer_command>
+      rest: [ { ws_pre: <ws>, comma: ",", ws_post: <ws>, command: <lexer_command> }, ... ]
+    }
+  ] | []
+  ws3: <optional whitespace>
+  semicolon: ";"
+}
+```
+
+### mode_decl
+
+```
+{
+  keyword: "mode"
+  ws1: <whitespace>
+  name: <identifier>
+  ws2: <optional whitespace>
+  semicolon: ";"
+}
+```
+
+### rule_body
+
+```
+{
+  first: <rule_alt>
+  rest: [ { ws1: <ws>, pipe: "|", ws2: <ws>, alt: <rule_alt> }, ... ]
+}
+```
+
+### rule_alt
+
+```
+{
+  first: <element_with_quantifier>
+  rest: [ { ws: <whitespace>, element: <element_with_quantifier> }, ... ]
+}
+```
+
+### element_with_quantifier
+
+```
+{
+  element: <string_literal | char_class | group | identifier | ".">
+  quantifier: "*" | "+" | "?" | "*?" | "+?" | "{n}" | ... | ""
+}
+```
+
+### group
+
+```
+{
+  open: "("
+  ws1: <optional whitespace>
+  body: <rule_body>
+  ws2: <optional whitespace>
+  close: ")"
+}
+```
+
+### lexer_command
+
+```
+{
+  name: <identifier>
+  args: [ { open: "(", ws1: <ws>, arg: <identifier>, ws2: <ws>, close: ")" } ] | []
 }
 ```
 
@@ -138,19 +254,9 @@ See the `tests/0` file for comprehensive examples of parsing and generation.
 
 ## Limitations
 
-Current implementation supports:
-- Grammar declarations
-- Basic parser rules (lowercase names)
-- Basic lexer rules (uppercase names)
-- String literals with single quotes
-- Character classes with ranges
-
-Not yet supported:
-- Rule alternatives (`|`)
-- Operators (`*`, `+`, `?`)
-- Parenthesized groups
-- Actions and semantic predicates
-- Grammar options
+- **Parenthesized Groups:** Currently supports up to 2 levels of nesting.
+- **Actions and Semantic Predicates:** Not yet supported.
+- **Grammar Options:** Not yet supported.
 
 Note: Comment syntax definitions (`single_line_comment`, `multi_line_comment`, `comment`) are available in the grammar for custom parsing needs.
 


### PR DESCRIPTION
Updated README.md to accurately reflect the current capabilities and structure of the ANTLR parser library. This includes documenting supported features (like alternatives, quantifiers, and groups), the new `to_dialect` API, and providing a comprehensive guide to the AST structure generated by the parser.

---
*PR created automatically by Jules for task [5420978217167418824](https://jules.google.com/task/5420978217167418824) started by @angelonuffer*